### PR TITLE
feat: add file upload page

### DIFF
--- a/src/app/components/survey/survey.component.ts
+++ b/src/app/components/survey/survey.component.ts
@@ -78,8 +78,8 @@ export class SurveyComponent {
 
     this.surveyModel = survey;
 
-    if (environment.useMixpanel) {
-      mixpanel.init(environment.mixpanelToken,
+    if (environment.analytics.useMixpanel) {
+      mixpanel.init(environment.analytics.mixpanelToken,
         { debug: true, track_pageview: true, persistence: 'localStorage' });
     }
   }
@@ -131,7 +131,7 @@ export class SurveyComponent {
   }
 
   onCurrentPageChanged(sender: SurveyCore.Model, options: SurveyCore.CurrentPageChangedEvent) {
-    if (environment.useMixpanel) {
+    if (environment.analytics.useMixpanel) {
       mixpanel.track('page_load', {
         'page_name': options.newCurrentPage.name
       });

--- a/src/assets/pilot.survey.json.ts
+++ b/src/assets/pilot.survey.json.ts
@@ -26,9 +26,9 @@ export const surveyJson = {
       "title": "Please upload your files",
       "storeDataAsText": true,
       "waitForUpload": true,
-      "allowMultiple": environment.allowMultipleFileUpload,
-      "maxSize": environment.maxFileSize,
-      "acceptedTypes": environment.acceptedFileTypes,
+      "allowMultiple": environment.fileUpload.allowMultipleFileUpload,
+      "maxSize": environment.fileUpload.maxFileSize,
+      "acceptedTypes": environment.fileUpload.acceptedFileTypes,
      }
     ]
    },

--- a/src/assets/pilot.survey.json.ts
+++ b/src/assets/pilot.survey.json.ts
@@ -26,8 +26,9 @@ export const surveyJson = {
       "title": "Please upload your files",
       "storeDataAsText": true,
       "waitForUpload": true,
-      "allowMultiple": true,
+      "allowMultiple": environment.allowMultipleFileUpload,
       "maxSize": environment.maxFileSize,
+      "acceptedTypes": environment.acceptedFileTypes,
      }
     ]
    },

--- a/src/assets/pilot.survey.json.ts
+++ b/src/assets/pilot.survey.json.ts
@@ -16,6 +16,21 @@ export const surveyJson = {
     ]
    },
    {
+    "name": "documentUploadPage",
+    "elements": [
+     {
+      "type": "file",
+      "name": "documentUpload",
+      "title": "Please upload your files",
+      "storeDataAsText": true,
+      "waitForUpload": true,
+      "allowMultiple": true,
+      "maxSize": 102400,
+      "hideNumber": true,
+       }
+      ]
+     },
+   {
     "name": "studentInfoStepsPage",
     "elements": [
      {

--- a/src/assets/pilot.survey.json.ts
+++ b/src/assets/pilot.survey.json.ts
@@ -1,3 +1,5 @@
+import { environment } from "../environments/environment";
+
 export const surveyJson = {
   "title": "Summer EBT Demo",
   "logoPosition": "right",
@@ -25,11 +27,10 @@ export const surveyJson = {
       "storeDataAsText": true,
       "waitForUpload": true,
       "allowMultiple": true,
-      "maxSize": 102400,
-      "hideNumber": true,
-       }
-      ]
-     },
+      "maxSize": environment.maxFileSize,
+     }
+    ]
+   },
    {
     "name": "studentInfoStepsPage",
     "elements": [

--- a/src/environments/environment.template
+++ b/src/environments/environment.template
@@ -7,10 +7,14 @@
 
 export const environment = {
     // For 3rd party integrations
-    useMixpanel: false,
-    mixpanelToken: '',
-    // For file upload
-    maxFileSize: 5000000, // 5MB in bytes
-    acceptedFileTypes: 'image/*,.jpeg,.jpg,.png,.pdf,.bmp,.doc,.docx,.odt,.ods,.odp',
-    allowMultipleFileUpload: true,
+    analytics: {
+      useMixpanel: false,
+      mixpanelToken: '',
+    },
+    fileUpload: {
+      // For file upload
+      maxFileSize: 5000000, // 5MB in bytes
+      acceptedFileTypes: 'image/*,.jpeg,.jpg,.png,.pdf,.bmp,.doc,.docx,.odt,.ods,.odp',
+      allowMultipleFileUpload: true,
+    },
 };

--- a/src/environments/environment.template
+++ b/src/environments/environment.template
@@ -8,4 +8,5 @@
 export const environment = {
     useMixpanel: false,
     mixpanelToken: '',
+    maxFileSize: 5000000, // 5MB in bytes
 };

--- a/src/environments/environment.template
+++ b/src/environments/environment.template
@@ -6,7 +6,11 @@
  * */
 
 export const environment = {
+    // For 3rd party integrations
     useMixpanel: false,
     mixpanelToken: '',
+    // For file upload
     maxFileSize: 5000000, // 5MB in bytes
+    acceptedFileTypes: 'image/*,.jpeg,.jpg,.png,.pdf,.bmp,.doc,.docx,.odt,.ods,.odp',
+    allowMultipleFileUpload: true,
 };


### PR DESCRIPTION
### Description

Add a new page to the survey which allows for files to be uploaded.

<img width="713" alt="Screenshot 2024-04-09 at 4 48 20 PM" src="https://github.com/codeforamerica/summer-ebt-surveyjs-demo/assets/67125998/40a03853-0fa1-45c3-a516-aaa997ce8c78">

- Add a file question type.
- Store the files as Base64 encoded within the survey data export
- Allow the upload of multiple files, based on configuration. The default is set to true
- Allow the max file size (per file, not total) to be configurable. The default is set to 5MB
- Support specific file types, based on configuration. The values set in the environment file for now are the same ones as for the LA digital assister
- Deleting files and displaying error messages is built in functionality that comes with this question type. The error message for exceeding the file size is shown below

<img width="690" alt="Screenshot 2024-04-09 at 4 48 38 PM" src="https://github.com/codeforamerica/summer-ebt-surveyjs-demo/assets/67125998/8e6620e0-7a31-47cf-ac96-71042f0384f1">

### Steps to test

- Bring up the application
- Navigate to the file upload page 
- Click on "Select file"
- Verify that only certain file types are selectable
- Upload a file. You can change the maxFileSize to test the error message
- Upload a second file by clicking on the folder icon, verify that you can upload more than one file
- Delete the files, either both at once or one by one
- Set allowMultipleFileUpload to false. Test selecting more than one file at once, which should not be possible. If you upload one file and then another, the second file will replace the first one.
- With one file uploaded, navigate to the end of the survey. Open the output data and verify that the uploaded file is stored as base64 encoded text.

### Future additions

- Beyond the demo, we should support uploading the files to a server. We should set storeDataAsText to false (configurable) and implement [onUploadFiles()](https://surveyjs.io/form-library/documentation/api-reference/survey-data-model#onUploadFiles).
- Accepted file types now are only used to filter in the upload menu, and are not validated in the backend. We should add validation in the future when we implement onUploadFiles(). This is not done now since onUploadFiles() is not called when data is stored as text.
- The icons for the file upload should be replaced.